### PR TITLE
Vue/Nuxt v0.1.6 Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14125,10 +14125,10 @@
     },
     "packages/nuxt": {
       "name": "@blro/ui-primitives-nuxt",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@blro/ui-primitives-vue": "^0.1.5",
+        "@blro/ui-primitives-vue": "^0.1.6",
         "@nuxt/kit": "^3.6.1"
       },
       "devDependencies": {
@@ -14151,7 +14151,7 @@
     },
     "packages/vue": {
       "name": "@blro/ui-primitives-vue",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blro/ui-primitives-nuxt",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/blro0319/ui-primitives.git",
@@ -8,6 +8,12 @@
   },
   "license": "MIT",
   "type": "module",
+  "files": [
+    "./dist"
+  ],
+  "main": "./dist/module.cjs",
+  "module": "./dist/module.mjs",
+  "types": "./dist/module.d.ts",
   "exports": {
     ".": {
       "types": "./dist/module.d.ts",
@@ -15,11 +21,6 @@
       "require": "./dist/module.cjs"
     }
   },
-  "main": "./dist/module.cjs",
-  "types": "./dist/module.d.ts",
-  "files": [
-    "./dist"
-  ],
   "scripts": {
     "build": "nuxt-module-build",
     "dev": "nuxi dev playground",
@@ -30,7 +31,7 @@
     "nuxt": "^3.0.0"
   },
   "dependencies": {
-    "@blro/ui-primitives-vue": "^0.1.5",
+    "@blro/ui-primitives-vue": "^0.1.6",
     "@nuxt/kit": "^3.6.1"
   },
   "devDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blro/ui-primitives-vue",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/blro0319/ui-primitives.git",
@@ -9,20 +9,25 @@
   "license": "MIT",
   "type": "module",
   "files": [
-    "dist"
+    "./dist"
   ],
+  "main": "./dist/primitives-vue.cjs",
+  "module": "./dist/primitives-vue.mjs",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/primitives-vue.es.js",
-      "require": "./dist/primitives-vue.umd.js"
+      "import": "./dist/primitives-vue.mjs",
+      "require": "./dist/primitives-vue.cjs"
     }
   },
-  "types": "dist/types/index.d.ts",
   "scripts": {
     "dev": "vite --host --port 3190",
     "build": "vite build && npm run build:types",
     "build:types": "vue-tsc --project tsconfig.build.json && tsc-alias --project tsconfig.build.json"
+  },
+  "peerDependencies": {
+    "vue": "^3.3.4"
   },
   "devDependencies": {
     "@babel/types": "^7.22.5",
@@ -44,8 +49,5 @@
     "vue": "^3.3.4",
     "vue-router": "^4.2.2",
     "vue-tsc": "^1.8.2"
-  },
-  "peerDependencies": {
-    "vue": "^3.3.4"
   }
 }

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "primitives-vue",
-      fileName: (format) => `primitives-vue.${format}.js`,
+      fileName(format) {
+        if (format === "es") return "primitives-vue.mjs";
+        return "primitives-vue.cjs";
+      },
     },
     rollupOptions: {
       external: ["vue"],


### PR DESCRIPTION
## Chore

- **vue**: Chagne exports name
- **nuxt**: Update `@blro/ui-primitives-vue` to v0.1.6
